### PR TITLE
fix: remove duplicate sitemap.xml homepage entry

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,12 +19,6 @@
         <priority>0.8</priority>
     </url>
   <url>
-    <loc>https://dhaval-info-1.github.io/Dhaval-Makwana/</loc>
-    <lastmod>2024-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
     <loc>https://dhaval-info-1.github.io/Dhaval-Makwana/#about</loc>
     <lastmod>2024-07-17</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Removes the duplicate and outdated sitemap URL entry for the homepage to improve search engine crawling efficiency.